### PR TITLE
Fix crash when context.diagnostics is empty in provideCodeActions()

### DIFF
--- a/src/features/ClangTidyProvider.ts
+++ b/src/features/ClangTidyProvider.ts
@@ -90,12 +90,16 @@ export default class ClangTidyProvider {
     public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext,
         token: CancellationToken): Command[] {
 
-        const diagnostics = context.diagnostics[0];
-        return [{
-            title: 'Apply clang-tidy fix',
-            command: ClangTidyProvider.commandId,
-            arguments: [document, diagnostics.range, diagnostics.message]
-        }];
+        if (context.diagnostics.length > 0)
+        {
+            const diagnostics = context.diagnostics[0];
+            return [{
+                title: 'Apply clang-tidy fix',
+                command: ClangTidyProvider.commandId,
+                arguments: [document, diagnostics.range, diagnostics.message]
+            }];
+        }
+        return [];
     }
 
     public activate(subscriptions: Disposable[]) {

--- a/src/features/ClangTidyProvider.ts
+++ b/src/features/ClangTidyProvider.ts
@@ -90,8 +90,7 @@ export default class ClangTidyProvider {
     public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext,
         token: CancellationToken): Command[] {
 
-        if (context.diagnostics.length > 0)
-        {
+        if (context.diagnostics.length > 0) {
             const diagnostics = context.diagnostics[0];
             return [{
                 title: 'Apply clang-tidy fix',


### PR DESCRIPTION
I don't know why context.diagnostics is empty even when diagnosticCollection is not empty for document.uri. It seems like context.diagnostic is supposed to get its value from diagnosticCollection.