### PR TITLE
Use '-' instead of '/dev/stdout' as the latter causes the error message 'Error opening output file: No such device or address'

### DIFF
--- a/src/features/ClangTidyProvider.ts
+++ b/src/features/ClangTidyProvider.ts
@@ -35,7 +35,7 @@ export default class ClangTidyProvider {
 
         const spawnOptions = workspace.rootPath ? { cwd: workspace.rootPath } : undefined;
 
-        let stdout = '/dev/stdout';
+        let stdout = '-';
         if (process.platform === 'win32') {
             stdout = 'CON';
         }


### PR DESCRIPTION
I don't know why /dev/stdout doesn't work. I've tested it only in Ubuntu Linux.