### PR TITLE
Add possibility to also run clang static analyzers

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,14 @@
                         "-Weverything"
                     ],
                     "description": "Extra arguments pass to compiler (-extra-arg=)"
-                }
+                },
+                "clangTidy.clangCheckArgs": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Clang static analyzer checks to run with clang-tidy"
+				}
             }
         }
     },

--- a/src/features/ClangTidyProvider.ts
+++ b/src/features/ClangTidyProvider.ts
@@ -51,6 +51,17 @@ export default class ClangTidyProvider {
             args.push('-extra-arg=' + arg);
         });
 
+        let argsNbr = configuration.clangCheckArgs.length;
+        if (argsNbr > 0) {
+            let checkArgs = "";
+            configuration.clangCheckArgs.forEach(arg => {
+                checkArgs += arg;
+                argsNbr > 0 ? checkArgs += ',' : 0;
+                argsNbr--;
+            });
+            args.push('-checks=' + checkArgs);
+        }
+
         const childProcess = spawn(configuration.executable, args, spawnOptions);
         console.log(spawnOptions);
         childProcess.on('error', console.error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,6 +121,17 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
         args.push('-extra-arg=' + arg);
     });
 
+    let argsNbr = configuration.clangCheckArgs.length;
+    if (argsNbr > 0) {
+        let checkArgs = "";
+        configuration.clangCheckArgs.forEach(arg => {
+            checkArgs += arg;
+            argsNbr > 0 ? checkArgs += ',' : 0;
+            argsNbr--;
+        });
+        args.push('-checks=' + checkArgs);
+    }
+
     const childProcess = spawn(configuration.executable, args, spawnOptions);
 
     childProcess.on('error', console.error);


### PR DESCRIPTION
This is the equivalent of the "-checks=" command, a list of different checks can be found here http://clang.llvm.org/extra/clang-tidy/