### PR TITLE
cpptools include path resolve, filter message by file path, better show error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.vsix
 /playground/
 .DS_Store
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ You may need to modify some default settings to get this extension to work for n
 
 `clangTidy.args`: Additional arguments to pass to `clang-tidy`
 
+`clangTidy.excludes`: Don't show message if file path of document in the excludes
+
+`clangTidy.workspaceOnly`: Limit messages to document on the workspaces folders
+
 If you want to configure the checks of clang tidy, create a `.clang-tidy` file in your working directory (please refer to the `clang-tidy`'s document for detail).
 
 ## Known Issues
@@ -50,11 +54,9 @@ I'm a beginner to vscode extension development, so if you have any suggestions, 
 
 3. Support for on-the-fly linting (if possible)
 
-4. Support for custom include paths through settings and by reading `.vscode/c_cpp_properties.json`
+4. Support for use custom `defines` in `.vscode/c_cpp_properties.json`
 
 5. Ship clang-tidy binaries
-
-6. Support for use custom `defines` in `.vscode/c_cpp_properties.json`
 
 ## Know Issues
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ I'm a beginner to vscode extension development, so if you have any suggestions, 
 
 5. Ship clang-tidy binaries
 
+6. Reconfiguration when `.vscode/c_cpp_properties.json`
+
 ## Know Issues
 
 - When using `-p compile_commands.json`, saving a header or opening a header file for the first time can clear existing quick fixes for that file.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ I'm a beginner to vscode extension development, so if you have any suggestions, 
 
 5. Ship clang-tidy binaries
 
+6. Support for use custom `defines` in `.vscode/c_cpp_properties.json`
+
 ## Know Issues
 
 - When using `-p compile_commands.json`, saving a header or opening a header file for the first time can clear existing quick fixes for that file.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,14 @@
                     },
                     "default": [],
                     "description": "Additional arguments to pass to clang-tidy"
+                },
+                "clangTidy.documentFilters": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Filter document if content any item of documentFilters"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -89,12 +89,12 @@
                         "type": "string"
                     },
                     "default": [],
-                    "description": "Don't show message if file path of document in excludes"
+                    "description": "Don't show message if file path of document in the excludes"
                 },
                 "clangTidy.workspaceOnly": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Filter message to workspaces folder"
+                    "description": "Limit messages to document on the workspaces folders"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
                         "type": "string"
                     },
                     "default": [],
-                    "description": "Don't show message if file path of document in documentFilters"
+                    "description": "Don't show message if file path of document in excludes"
                 },
                 "clangTidy.workspaceOnly": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -83,13 +83,18 @@
                     "default": [],
                     "description": "Additional arguments to pass to clang-tidy"
                 },
-                "clangTidy.documentFilters": {
+                "clangTidy.excludes": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
                     "default": [],
-                    "description": "Filter document if content any item of documentFilters"
+                    "description": "Don't show message if file path of document in documentFilters"
+                },
+                "clangTidy.workspaceOnly": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Filter message to workspaces folder"
                 }
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,136 @@
+import Uri from 'vscode-uri';
+import * as path from 'path';
+import * as fs from 'fs';
+import { WorkspaceFolder } from "vscode-languageclient";
+
+export function isValide(filePath: string, config: Configuration, workspaceFolders: WorkspaceFolder[]): boolean {
+  if (config.excludes && config.excludes.some(s => filePath.includes(s))) {
+    return false;
+  }
+
+  if (config.workspaceOnly && workspaceFolders &&
+    !workspaceFolders.some(s => filePath.startsWith(Uri.parse(s.uri).fsPath))) {
+    return false;
+  }
+
+  return true;
+}
+
+// resolve {$workspaceFolder} and {$workspaceFolder:Name} in pathIn
+// resolve relative path base on workspaceFolder
+function resolvePath(pathIn: string, workspaceFolder: string, workspaceFolders: WorkspaceFolder[]): string {
+  let s = pathIn.replace('${workspaceFolder}', workspaceFolder);
+  if (workspaceFolders) {
+    workspaceFolders.forEach(wf => {
+      s = s.replace('${workspaceFolder:' + wf.name + '}',
+        Uri.parse(wf.uri).fsPath);
+    });
+  }
+  return path.resolve(workspaceFolder, s);
+}
+
+function walkDir(dir: string, recursive: boolean, fn: (dir: string) => void) {
+  fs.readdirSync(dir).forEach(file => {
+    const s = path.join(dir, file);
+    if (fs.lstatSync(s).isDirectory()) {
+      fn(s);
+      walkDir(s, recursive, fn);
+    }
+  });
+}
+
+function readConfigFromCppTools(workspaceFolders: WorkspaceFolder[]): CppToolsConfigs {
+  const cppToolsIncludePaths: string[] = [];
+  let cStandard: string = '';
+  let cppStandard: string = '';
+
+  function pushIncPath(s: string) {
+    if (cppToolsIncludePaths.indexOf(s) < 0) {
+      cppToolsIncludePaths.push(s);
+    }
+  }
+
+  workspaceFolders.forEach(folder => {
+    const workspacePath = Uri.parse(folder.uri).fsPath;
+    const config = path.join(workspacePath, '.vscode/c_cpp_properties.json');
+    if (fs.existsSync(config)) {
+      const content = fs.readFileSync(config, { encoding: 'utf8' });
+      const configJson = JSON.parse(content);
+      if (configJson.configurations) {
+        configJson.configurations.forEach((config: any) => {
+          if (config.includePath) {
+            config.includePath.forEach((incPath: string) => {
+              incPath = resolvePath(incPath, workspacePath, workspaceFolders);
+              if (incPath.endsWith('/**')) {
+                const s = incPath.substring(0, incPath.length - 3);
+                pushIncPath(s);
+                walkDir(s, true, (dir: string) => {
+                  pushIncPath(dir);
+                });
+              } else if (incPath.endsWith('/*')) {
+                const s = incPath.substring(0, incPath.length - 2);
+                pushIncPath(s);
+                walkDir(s, false, (dir: string) => {
+                  pushIncPath(dir);
+                });
+              } else {
+                pushIncPath(incPath);
+              }
+            });
+          }
+          cStandard = config.cStandard;
+          cppStandard = config.cppStandard;
+        });
+      }
+    }
+  });
+
+  return {
+    cppToolsIncludePaths, cStandard, cppStandard
+  };
+}
+
+export function initConfig(configuration: Configuration, workspaceFolders: WorkspaceFolder[]): Configuration {
+
+  configuration.defaultWorkspaceFolder = workspaceFolders && workspaceFolders.length > 0 ?
+    Uri.parse(workspaceFolders[0].uri).fsPath : '.';
+
+  configuration.excludes.forEach((exclude, index) => {
+    configuration.excludes[index] = resolvePath(exclude, configuration.defaultWorkspaceFolder, workspaceFolders)
+  });
+
+  configuration.args.push('--export-fixes=-');
+
+  if (configuration.headerFilter) {
+    configuration.args.push('-header-filter=' + configuration.headerFilter);
+  }
+
+  configuration.systemIncludePath.forEach(path => {
+    const arg = '-extra-arg=-isystem' + resolvePath(path, configuration.defaultWorkspaceFolder, workspaceFolders);
+    configuration.args.push(arg);
+  });
+
+  configuration.extraCompilerArgs.forEach(arg => {
+    configuration.args.push('-extra-arg-before=' + arg);
+  });
+
+  configuration.args.forEach(arg => {
+    configuration.args.push(arg);
+  });
+
+  if (workspaceFolders) {
+    const cppToolsConfigs = readConfigFromCppTools(workspaceFolders);
+    if (cppToolsConfigs) {
+      const { cppToolsIncludePaths, cStandard, cppStandard } = cppToolsConfigs;
+      configuration.cStandard = cStandard;
+      configuration.cppStandard = cppStandard;
+      cppToolsIncludePaths.forEach(path => {
+        const arg = '-extra-arg=-I' + path;
+        configuration.args.push(arg);
+      });
+    }
+  }
+
+
+  return configuration;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,8 @@ function readConfigFromCppTools(workspaceFolders: WorkspaceFolder[]): CppToolsCo
 
 export function initConfig(configuration: Configuration, workspaceFolders: WorkspaceFolder[]): Configuration {
 
+  configuration.genArgs = [];
+
   configuration.defaultWorkspaceFolder = workspaceFolders && workspaceFolders.length > 0 ?
     Uri.parse(workspaceFolders[0].uri).fsPath : '.';
 
@@ -99,23 +101,23 @@ export function initConfig(configuration: Configuration, workspaceFolders: Works
     configuration.excludes[index] = resolvePath(exclude, configuration.defaultWorkspaceFolder, workspaceFolders)
   });
 
-  configuration.args.push('--export-fixes=-');
+  configuration.genArgs.push('--export-fixes=-');
 
   if (configuration.headerFilter) {
-    configuration.args.push('-header-filter=' + configuration.headerFilter);
+    configuration.genArgs.push('-header-filter=' + configuration.headerFilter);
   }
 
   configuration.systemIncludePath.forEach(path => {
     const arg = '-extra-arg=-isystem' + resolvePath(path, configuration.defaultWorkspaceFolder, workspaceFolders);
-    configuration.args.push(arg);
+    configuration.genArgs.push(arg);
   });
 
   configuration.extraCompilerArgs.forEach(arg => {
-    configuration.args.push('-extra-arg-before=' + arg);
+    configuration.genArgs.push('-extra-arg-before=' + arg);
   });
 
   configuration.args.forEach(arg => {
-    configuration.args.push(arg);
+    configuration.genArgs.push(arg);
   });
 
   if (workspaceFolders) {
@@ -126,7 +128,7 @@ export function initConfig(configuration: Configuration, workspaceFolders: Works
       configuration.cppStandard = cppStandard;
       cppToolsIncludePaths.forEach(path => {
         const arg = '-extra-arg=-I' + path;
-        configuration.args.push(arg);
+        configuration.genArgs.push(arg);
       });
     }
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,7 +5,8 @@ interface Configuration {
     extraCompilerArgs: string[];
     headerFilter: string;
     args: string[];
-    documentFilters: string[];
+    excludes: string[];
+    workspaceOnly: boolean;
 }
 
 interface ClangTidyResult {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,6 +5,7 @@ interface Configuration {
     extraCompilerArgs: string[];
     headerFilter: string;
     args: string[];
+    documentFilters: string[];
 }
 
 interface ClangTidyResult {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -38,7 +38,12 @@ interface ClangTidyReplacement {
     Offset: number;
     Length: number;
     ReplacementText: string;
-    Range?: Range;  // Offset and length translated into line character
+    //Range?: Range;  // Offset and length translated into line character
+}
+
+interface ClangTidyReplacementFix {
+    t: string;
+    r?: Range;  // Offset and length translated into line character
 }
 
 interface CppToolsConfigs {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,6 +7,11 @@ interface Configuration {
     args: string[];
     excludes: string[];
     workspaceOnly: boolean;
+
+    defaultWorkspaceFolder: string;
+    genArgs: string[];
+    cStandard: string;
+    cppStandard: string;
 }
 
 interface ClangTidyResult {

--- a/src/server.ts
+++ b/src/server.ts
@@ -230,13 +230,12 @@ async function provideCodeActions(params: CodeActionParams): Promise<CodeAction[
                         changes
                     }
                 });
-
             } else {
-                actions.push({
-                    title: 'Apply clang-tidy fix [NYI]',
-                    diagnostics: [d],
-                    kind: CodeActionKind.QuickFix
-                });
+                // actions.push({
+                //     title: 'Apply clang-tidy fix [NYI]',
+                //     diagnostics: [d],
+                //     kind: CodeActionKind.QuickFix
+                // });
             }
         });
     return actions;

--- a/src/server.ts
+++ b/src/server.ts
@@ -99,7 +99,7 @@ function getAlternativeDoc(filePath: string, languageId: string): TextDocument |
     // Assume it's a header file and look for a matching source file in the same directory.
     // It would be better to query VSCode for this as it has better overall visibility of matching source to header.
     const basePath = path.parse(Uri.parse(filePath).fsPath);
-    const tryExtensions = ["c", "cpp", "cxx"];
+    const tryExtensions = ["c", "cpp", "cxx", "cc"];
 
     for (const ext of tryExtensions) {
         const tryPath = path.join(basePath.dir, basePath.name + "." + ext);

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,8 @@ const defaultConfig: Configuration = {
     lintLanguages: ["c", "cpp"],
     extraCompilerArgs: ["-Weverything"],
     headerFilter: ".*",
-    args: []
+    args: [],
+    documentFilters: []
 };
 
 let globalConfig = defaultConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,8 @@ const defaultConfig: Configuration = {
     extraCompilerArgs: ["-Weverything"],
     headerFilter: ".*",
     args: [],
-    documentFilters: []
+    excludes: [],
+    workspaceOnly: false
 };
 
 let globalConfig = defaultConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import Uri from 'vscode-uri';
 import { generateDiagnostics } from './tidy';
 import * as path from 'path';
 import * as fs from 'fs';
-import { isValide } from "./utils";
+import { isValide, inWorkspaceTest } from "./utils";
 import { initConfig } from "./config";
 
 // update by https://github.com/Microsoft/vscode-eslint/blob/master/server/src/eslintServer.ts
@@ -137,8 +137,11 @@ function getDocumentConfig(resource: string, workspaceFolders: WorkspaceFolder[]
             scopeUri: resource,
             section: 'clangTidy'
         });
-        documentConfig.set(resource, result.then(v => {
-            return initConfig(v, workspaceFolders);
+        documentConfig.set(resource, result.then(config => {
+            if (inWorkspaceTest(Uri.parse(resource).fsPath, config, workspaceFolders)) {
+                return initConfig(config, workspaceFolders);
+            }
+            return config;
         }));
     }
     return result;

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -116,7 +116,7 @@ export function generateDiagnostics(
 
     function resolveFilePath(filePath: string): string {
         if (filePath === '') {
-            return '';
+            return textDocumentPath;
         }
 
         filePath = path.resolve(filePath);
@@ -189,7 +189,6 @@ export function generateDiagnostics(
             const parsed = safeLoad(yaml) as ClangTidyResult;
             parsed.Diagnostics.forEach((element: ClangTidyDiagnostic) => {
                 element.FilePath = resolveFilePath(element.FilePath);
-
                 if (element.FilePath === '') {
                     return;
                 }

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -173,7 +173,7 @@ export function generateDiagnostics(
                     const clangTidySourceName: string = 'Clang Tidy';
 
                     // Ensure an absolute path for the main clang-tidy element.
-                    element.FilePath = fixPath(element.FilePath);
+                    element.FilePath = fixPath(filePath);
 
                     // Iterate the replacements to:
                     // - Ensure absolute paths.

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -104,6 +104,9 @@ export function generateDiagnostics(
     // console.warn("clang-tidy with args: " + args);
     const childProcess = spawn(configuration.executable, args);
 
+    const docFilters = configuration.documentFilters;
+    const docFiltersCount = docFilters.length;
+
     childProcess.on('error', console.error);
     if (childProcess.pid) {
         childProcess.stdout.on('data', (data) => {
@@ -115,6 +118,15 @@ export function generateDiagnostics(
                 const yaml = match[0];
                 const parsed = safeLoad(yaml) as ClangTidyResult;
                 parsed.Diagnostics.forEach((element: ClangTidyDiagnostic) => {
+                    if (docFiltersCount > 0) {
+                        const filePath = element.FilePath;
+                        for (let i = 0; i < docFiltersCount; i++) {
+                            if (filePath.includes(docFilters[i])) {
+                                return;
+                            }
+                        }
+                    }
+
                     const name: string = element.DiagnosticName;
                     const severity = name.endsWith('error') ?
                         DiagnosticSeverity.Error : DiagnosticSeverity.Warning;

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -57,7 +57,7 @@ export function generateDiagnostics(
     // Immediately add entries for the textDocument.
     diagnostics[textDocumentPath] = [];
     docs[textDocumentPath] = textDocument;
-    const args = configuration.args;
+    const args = configuration.genArgs;
 
     if (textDocument.languageId === 'c') {
         args.push('-extra-arg-before=-xc');

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -97,7 +97,14 @@ export function generateDiagnostics(
     if (workspaceFolders) {
         const workspaceFolder = Uri.parse(workspaceFolders[0].uri).fsPath;
         args.forEach(function (arg, index) {
-            args[index] = arg.replace("${workspaceFolder}", workspaceFolder);
+            args[index] = arg.replace('${workspaceFolder}', workspaceFolder);
+        });
+
+        workspaceFolders.forEach(workspaceFolder => {
+            const path = Uri.parse(workspaceFolder.uri).fsPath;
+            args.forEach(function (arg, index) {
+                args[index] = arg.replace('${workspaceFolder:' + workspaceFolder.name + "}", path);
+            });
         });
     }
 
@@ -243,7 +250,12 @@ function readConfigFromCppTools(workspaceFolders: WorkspaceFolder[]): CppToolsCo
                 configJson.configurations.forEach((config: any) => {
                     if (config.includePath) {
                         config.includePath.forEach((incPath: string) => {
-                            incPath = incPath.replace('${workspaceFolder}', '.');
+                            incPath = incPath.replace('${workspaceFolder}', workspacePath);
+                            workspaceFolders.forEach(wf => {
+                                incPath = incPath.replace('${workspaceFolder:' + wf.name + '}',
+                                    Uri.parse(wf.uri).fsPath);
+                            });
+
                             if (incPath.endsWith('**')) {
                                 let s = incPath.substring(0, incPath.length - 2);
                                 s = path.resolve(workspacePath, s);

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -55,7 +55,7 @@ export function generateDiagnostics(
     // Keyed on absolute file name.
     const docs: { [id: string]: TextDocument } = {};
     const defWorkspaceFolder = workspaceFolders && workspaceFolders.length > 0 ?
-        Uri.parse(workspaceFolders[0].uri).fsPath : '';
+        Uri.parse(workspaceFolders[0].uri).fsPath : '.';
 
     let cppToolsConfigs: CppToolsConfigs | null = null;
     if (workspaceFolders) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,19 @@
 import Uri from 'vscode-uri';
 import { WorkspaceFolder } from "vscode-languageclient";
 
-export function isValide(filePath: string, config: Configuration, workspaceFolders: WorkspaceFolder[]): boolean {
-  if (config.excludes && config.excludes.some(s => filePath.includes(s))) {
-    return false;
-  }
-
+export function inWorkspaceTest(filePath: string, config: Configuration, workspaceFolders: WorkspaceFolder[]): boolean {
   if (config.workspaceOnly && workspaceFolders &&
     !workspaceFolders.some(s => filePath.startsWith(Uri.parse(s.uri).fsPath))) {
     return false;
   }
 
   return true;
+}
+
+export function isValide(filePath: string, config: Configuration, workspaceFolders: WorkspaceFolder[]): boolean {
+  if (config.excludes && config.excludes.some(s => filePath.includes(s))) {
+    return false;
+  }
+
+  return inWorkspaceTest(filePath, config, workspaceFolders);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,15 @@
+import Uri from 'vscode-uri';
+import { WorkspaceFolder } from "vscode-languageclient";
+
+export function isValide(filePath: string, config: Configuration, workspaceFolders: WorkspaceFolder[]): boolean {
+  if (config.excludes && config.excludes.some(s => filePath.includes(s))) {
+    return false;
+  }
+
+  if (config.workspaceOnly && workspaceFolders &&
+    !workspaceFolders.some(s => filePath.startsWith(Uri.parse(s.uri).fsPath))) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
cpptools include path resolve :
  - . and ..
  - \* and ** in end
  - ${workspaceFolder}
  - ${workspaceFolder:Name} in multi root work space

filter message by document file path with properties:
  - clangTidy.excludes: Don't show message if file path of document in excludes
  - clangTidy.workspaceOnly: Filter message to workspaces folder

better show error:
  - Show error from compiler error (parse output)
  - Show warning from Tidy (YAML data)