### PR TITLE
Generic improvements.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,14 @@
             "preLaunchTask": "npm: watch"
         },
         {
+			"type": "node",
+			"request": "attach",
+			"name": "Language Server",
+			"port": 6009,
+			"restart": true,
+            "outFiles": ["${workspaceRoot}/out/**/*.js"],
+		},
+        {
             "name": "Extension Tests",
             "type": "extensionHost",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,5 +40,11 @@
             ],
             "preLaunchTask": "npm: watch"
         }
+    ],
+    "compounds": [
+        {
+            "name": "Extension/Language Server",
+            "configurations": ["Extension", "Language Server"]
+        }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
                     "default": "${workspaceFolder}",
                     "description": "Filters out shown diagnostics to prevent issues outside of user's code being shown and improves the performance"
                 },
+                "clangTidy.compileCommands": {
+                    "type": "string",
+                    "default": "${workspaceFolder}/compile_commands.json",
+                    "description": "Sets the location of compile_commands.json that's passed via cmd arguments"
+                },
                 "clangTidy.args": {
                     "type": "array",
                     "items": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                     "default": ".*",
                     "description": "Value for clang-tidy '-header-filter' command line argument"
                 },
+                "clangTidy.diagnosticFilter": {
+                    "type": "string",
+                    "default": "${workspaceFolder}",
+                    "description": "Filters out shown diagnostics to prevent issues outside of user's code being shown and improves the performance"
+                },
                 "clangTidy.args": {
                     "type": "array",
                     "items": {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,6 +5,7 @@ interface Configuration {
     extraCompilerArgs: string[];
     headerFilter: string;
     args: string[];
+    diagnosticFilter: string;
 }
 
 interface ClangTidyResult {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,6 +6,7 @@ interface Configuration {
     headerFilter: string;
     args: string[];
     diagnosticFilter: string;
+    compileCommands: string;
 }
 
 interface ClangTidyResult {

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,8 @@ const defaultConfig: Configuration = {
     extraCompilerArgs: ["-Weverything"],
     headerFilter: ".*",
     args: [],
-    diagnosticFilter: "${workspaceFolder}"
+    diagnosticFilter: "${workspaceFolder}",
+    compileCommands: "${workspaceFolder}/compile_commands.json"
 };
 
 let globalConfig = defaultConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,8 @@ const defaultConfig: Configuration = {
     lintLanguages: ["c", "cpp"],
     extraCompilerArgs: ["-Weverything"],
     headerFilter: ".*",
-    args: []
+    args: [],
+    diagnosticFilter: "${workspaceFolder}"
 };
 
 let globalConfig = defaultConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -221,14 +221,16 @@ async function provideCodeActions(params: CodeActionParams): Promise<CodeAction[
                     }
                 }
 
-                actions.push({
-                    title: '[Clang Tidy] Change to ' + replacements[0].ReplacementText,
-                    diagnostics: [d],
-                    kind: CodeActionKind.QuickFix,
-                    edit: {
-                        changes
-                    }
-                });
+                if (replacements.length) {
+                    actions.push({
+                        title: '[Clang Tidy] Change to ' + replacements[0].ReplacementText,
+                        diagnostics: [d],
+                        kind: CodeActionKind.QuickFix,
+                        edit: {
+                            changes
+                        }
+                    });
+                }
 
             } else {
                 actions.push({

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -57,6 +57,10 @@ export function generateDiagnostics(
         args.push('-header-filter=' + configuration.headerFilter);
     }
 
+    if (configuration.compileCommands) {
+        args.push('-p=' + configuration.compileCommands);
+    }
+
     configuration.systemIncludePath.forEach(path => {
         const arg = '-extra-arg=-isystem' + path;
         args.push(arg);


### PR DESCRIPTION
Hey!

Thanks for the project. Definitely makes my life easier :)

Sorry if the PR has too much variety. These are the improvements the my workspace needed. 
I'll break it down if you'd prefer it that way.

Here are fixes for some issues that I've faced while working with the extension:

- Implemented `diagnosticFilter`
  This setting filters out shown diagnostics to prevent issues outside of
user's code being shown and improves the performance by not creating as
many diagnostic messages due to 3rd party code (especially useful for git submodule based dependencies). In my project, the warnings went from 3000+ to 5 this way.

  In some cases Clang Tidy may also show warnings from 3rd party files due
to preprocessor macros and include files, irrelevent of the specified
header-filter or CPP files
(https://stackoverflow.com/questions/39527160/clang-tidy-how-to-suppress-warnings).
This effectively acts as a workaround for those cases too.

- Fixed "Cannot read property `ReplacementText` of `undefined`" errors in the output
  Clang-tidy didn't have suggested fixes in some cases, causing an exception being thrown.

- Added configuration option to explicitly set the location of compile_commands.json
  I nice setting for people who don't want to deal with `argv`.

- Ensured that only replacements with actual `ReplacementText` are registered
  This way, Quick Fix code action can actually select possible fixes more reliably.
  Empty redundant data also doesn't get displayed in diagnostics views.
  Comes with a performance improvement since we skip `JSON.stringify` and sending empty data in most cases.


Some developer oriented stuff:
- Added a launch task for attaching a debugger to the language server
  Debugging the server process is now possible.
- Added a compound launch task that starts the debugging of both the client extension and the server
  For convenience.